### PR TITLE
SCHED-27 add recordings datasource with job name filter on job update…

### DIFF
--- a/application-home/conf/config.xml
+++ b/application-home/conf/config.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<applicationRootConfig xmlns="http://www.appng.org/schema/platform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.appng.org/schema/platform http://www.appng.org/schema/platform/appng-platform.xsd">
+<applicationRootConfig xmlns="http://www.appng.org/schema/platform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.appng.org/schema/platform http://www.appng.org/schema/platform/appng-platform.xsd">
 	<name>Scheduler</name>
 	<config>
 		<permissions>
@@ -33,6 +32,7 @@
 					<url-params>
 						<url-param name="action" />
 						<url-param name="id" />
+						<url-param name="recordId" />
 					</url-params>
 					<get-params>
 						<get-param name="form_action" />
@@ -107,6 +107,24 @@
 							</params>
 						</action>
 					</element>
+					<element>
+						<datasource id="records">
+							<condition expression="${action eq 'update'}" />
+							<params>
+								<param name="jobId">${id}</param>
+								<param name="path">/jobs/update/${id}</param>
+								<param name="tab">#tab_update</param>
+							</params>
+						</datasource>
+					</element>
+					<element>
+						<action eventId="jobEvent" id="showRecordDetails">
+							<condition expression="${not empty recordId}" />
+							<params>
+								<param name="recordId">${recordId}</param>
+							</params>
+						</action>
+					</element>
 				</section>
 			</structure>
 		</page>
@@ -130,7 +148,11 @@
 			<structure>
 				<section>
 					<element>
-						<datasource id="records" />
+						<datasource id="records">
+							<params>
+								<param name="path">/records</param>
+							</params>
+						</datasource>
 					</element>
 					<element>
 						<action eventId="jobEvent" id="showRecordDetails">

--- a/application-home/conf/datasource.xml
+++ b/application-home/conf/datasource.xml
@@ -127,6 +127,9 @@
 		<config>
 			<title>records.list</title>
 			<params>
+				<param name="jobId" />
+				<param name="path" />
+				<param name="tab" />
 			</params>
 			<meta-data bindClass="org.appng.application.scheduler.model.JobRecord">
 				<field name="siteName" type="text">
@@ -158,13 +161,15 @@
 
 			</meta-data>
 			<linkpanel id="actions" location="inline">
-				<link mode="intern" target="/records/${current.id}" default="true">
+				<link mode="intern" target="${path}/${current.id}${tab}" default="true">
 					<label>record.details</label>
 					<icon>detail</icon>
 				</link>
 			</linkpanel>
 		</config>
-		<bean id="records" />
+		<bean id="records">
+			<option name="jobId" value="${jobId}" />
+		</bean>
 	</datasource>
 
 

--- a/src/main/java/org/appng/application/scheduler/business/Records.java
+++ b/src/main/java/org/appng/application/scheduler/business/Records.java
@@ -67,8 +67,11 @@ public class Records implements DataProvider {
 			Request request, FieldProcessor fieldProcessor) {
 		DataContainer dc = new DataContainer(fieldProcessor);
 		String recordId = options.getOptionValue("id", "value");
-
-		if (StringUtils.isNotBlank(recordId)) {
+		String jobId = options.getOptionValue("jobId", "value");
+		if (StringUtils.isNotBlank(jobId)) {
+			List<JobRecord> records = jobRecordService.getRecords(site.getName(), null, jobId, null, null, null, null);
+			dc.setPage(records, fieldProcessor.getPageable());
+		} else if (StringUtils.isNotBlank(recordId)) {
 
 			JobRecord item = jobRecordService.getRecord(site.getName(), recordId);
 			dc.setItem(item);

--- a/src/test/java/org/appng/application/scheduler/TestJobRecordings.java
+++ b/src/test/java/org/appng/application/scheduler/TestJobRecordings.java
@@ -3,6 +3,7 @@ package org.appng.application.scheduler;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,7 +91,7 @@ public class TestJobRecordings extends TestBase {
 	public void testGetRecords() throws Exception {
 
 		CallableDataSource datasource = getDataSource("records").getCallableDataSource();
-		Data perform = datasource.perform("page");
+		datasource.perform("page");
 		validate(datasource.getDatasource());
 		verify(jdbcTemplate).query(eq(
 				"SELECT DISTINCT application FROM job_execution_record WHERE site = :site ORDER BY application DESC"),
@@ -98,8 +99,27 @@ public class TestJobRecordings extends TestBase {
 		verify(jdbcTemplate).query(
 				eq("SELECT DISTINCT job_name FROM job_execution_record WHERE site = :site ORDER BY job_name DESC"),
 				any(MapSqlParameterSource.class), any(RowMapper.class));
-		verify(jdbcTemplate).query(eq(
-				"SELECT * FROM job_execution_record WHERE site = :site ORDER BY start_time DESC;"),
+		verify(jdbcTemplate).query(
+				eq("SELECT * FROM job_execution_record WHERE site = :site ORDER BY start_time DESC;"),
+				any(MapSqlParameterSource.class), any(RowMapper.class));
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetRecordsForJobId() throws Exception {
+
+		CallableDataSource datasource = getDataSource("records").withParam("jobId", "foo").getCallableDataSource();
+		datasource.perform("page");
+		validate(datasource.getDatasource());
+		verify(jdbcTemplate, never()).query(eq(
+				"SELECT DISTINCT application FROM job_execution_record WHERE site = :site ORDER BY application DESC"),
+				any(MapSqlParameterSource.class), any(RowMapper.class));
+		verify(jdbcTemplate, never()).query(
+				eq("SELECT DISTINCT job_name FROM job_execution_record WHERE site = :site ORDER BY job_name DESC"),
+				any(MapSqlParameterSource.class), any(RowMapper.class));
+		verify(jdbcTemplate, times(1)).query(eq(
+				"SELECT * FROM job_execution_record WHERE site = :site AND job_name = :job_name ORDER BY start_time DESC;"),
 				any(MapSqlParameterSource.class), any(RowMapper.class));
 
 	}

--- a/src/test/resources/xml/TestJobRecordings-testGetRecordsForJobId.xml
+++ b/src/test/resources/xml/TestJobRecordings-testGetRecordsForJobId.xml
@@ -3,7 +3,7 @@
     <config>
         <title id="records.list">Recorded Job Executions</title>
         <params>
-            <param name="jobId"/>
+            <param name="jobId">foo</param>
             <param name="path"/>
             <param name="tab"/>
         </params>
@@ -43,34 +43,6 @@
         </linkpanel>
     </config>
     <data>
-        <selectionGroup>
-            <selection id="ap">
-                <title id="filter.record.applicationName">Application</title>
-                <option value="" name="" selected="false"/>
-            </selection>
-            <selection id="job">
-                <title id="filter.record.jobName">Job Name</title>
-                <option value="" name="" selected="false"/>
-            </selection>
-            <selection id="re">
-                <title id="filter.record.result">Result</title>
-                <option value="" name="" selected="false"/>
-                <option value="SUCCESS" name="SUCCESS" selected="false"/>
-                <option value="FAIL" name="FAIL" selected="false"/>
-            </selection>
-            <selection id="du" type="text">
-                <title id="filter.record.minDuration">Min Duration (s)</title>
-                <option value="" name="du"/>
-            </selection>
-            <selection id="sa" type="date" format="yyyy-MM-dd HH:mm">
-                <title id="filter.record.startedAfter">Started After</title>
-                <option value="" name="sa"/>
-            </selection>
-            <selection id="sb" type="date" format="yyyy-MM-dd HH:mm">
-                <title id="filter.record.startedBefore">Started Before</title>
-                <option value="" name="sb"/>
-            </selection>
-        </selectionGroup>
         <resultset chunk="0" chunkname="records" chunksize="25" nextchunk="0" previouschunk="0" firstchunk="0" lastchunk="-1" hits="0"/>
     </data>
 </datasource>

--- a/src/test/resources/xml/TestJobRecordings-testGetRecordsWithFilter.xml
+++ b/src/test/resources/xml/TestJobRecordings-testGetRecordsWithFilter.xml
@@ -2,7 +2,11 @@
 <datasource xmlns="http://www.appng.org/schema/platform" id="records">
     <config>
         <title id="records.list">Recorded Job Executions</title>
-        <params/>
+        <params>
+            <param name="jobId"/>
+            <param name="path"/>
+            <param name="tab"/>
+        </params>
         <meta-data bindClass="org.appng.application.scheduler.model.JobRecord">
             <field name="siteName" type="text" binding="siteName">
                 <label id="record.site">Site</label>
@@ -32,7 +36,7 @@
             </field>
         </meta-data>
         <linkpanel id="actions" location="inline">
-            <link id="actions[1]" mode="intern" target="/records/${current.id}" default="true">
+            <link id="actions[1]" mode="intern" target="/${current.id}" default="true">
                 <label id="record.details">Show Details</label>
                 <icon>detail</icon>
             </link>


### PR DESCRIPTION
When the user gets on the update page of a job to see the details about a job, the list of recorded job execution events of that particular job are shown beyond the update form. It also provides the details of a record on same page if the user wants to see them. 