### PR TITLE
appng scheduler 1.11.x

### DIFF
--- a/scripts/icinga/appng-check_scheduled_job_executions.py
+++ b/scripts/icinga/appng-check_scheduled_job_executions.py
@@ -45,8 +45,8 @@ class JobExecutions(nagiosplugin.Resource):
 def main(warn, crit, url, token, jobname, hours, sslverify):
     """ Nagios/Icinga check script for checking successful executions of scheduled jobs in appNG """
     check = nagiosplugin.Check(
-        JobExecutions(url, token, jobname, hours),
-        nagiosplugin.ScalarContext('JobExecutions', warn, crit))
+        JobExecutions(url, token, jobname, hours, sslverify),
+        nagiosplugin.ScalarContext('JobExecutions', str(warn), str(crit)))
     check.main()
     return 0
 

--- a/scripts/icinga/appng-check_scheduled_job_executions.py
+++ b/scripts/icinga/appng-check_scheduled_job_executions.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
-#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-#                    Version 2, December 2004
-#
-# Copyright (C) 2004 Sam Hocevar
-#  14 rue de Plaisance, 75014 Paris, France
-# Everyone is permitted to copy and distribute verbatim or modified
-# copies of this license document, and changing it is allowed as long
-# as the name is changed.
-#
-#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-#   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-#
-#  0. You just DO WHAT THE FUCK YOU WANT TO.
-#
 
 import requests
 from datetime import datetime, timedelta

--- a/scripts/icinga/appng-check_scheduled_job_executions.py
+++ b/scripts/icinga/appng-check_scheduled_job_executions.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+#
+# Copyright 2011-2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import requests
 from datetime import datetime, timedelta
 import sys


### PR DESCRIPTION
- Added option to disable ssl host verification
- Refer warn/crit thresholds as plain str type as its checked later in nagiosplugins.Range and leads to a unsupported range type exception
- Removed WTFPL as we use apache 2 license for our whole appNG project